### PR TITLE
cmake generated files for the workflows in in iPlugOOS template

### DIFF
--- a/.github/workflows/build-native.yml
+++ b/.github/workflows/build-native.yml
@@ -45,7 +45,9 @@ jobs:
     - name: Build macOS
       if: matrix.os == 'macOS-latest'
       run: |
-        cd ${{env.PROJECT_NAME}}/scripts
+        cd ${{env.PROJECT_NAME}}
+        cmake -G Xcode -S . -B build-mac
+        cd scripts
         ./makedist-mac.sh full zip
       shell: bash
 
@@ -56,7 +58,9 @@ jobs:
     - name: Build Windows
       if: matrix.os == 'windows-latest'
       run: |
-        cd ${{env.PROJECT_NAME}}\scripts
+        cd ${{env.PROJECT_NAME}}
+        cmake -S . -B build-win
+        cd scripts
         .\makedist-win.bat full zip
       shell: pwsh
 

--- a/TemplateProject/CMakeLists.txt
+++ b/TemplateProject/CMakeLists.txt
@@ -41,7 +41,7 @@ iplug_target_add(_base INTERFACE
   FEATURE cxx_std_17)
 
 # For typing convenience the TARGET name is put into a variable.
-set(TARGET app)
+set(TARGET ${PROJECT_NAME}-app)
 add_executable(${TARGET} WIN32 MACOSX_BUNDLE ${SRC_FILES})
 iplug_target_add(${TARGET} PUBLIC LINK iPlug2_APP _base RESOURCE ${RESOURCES})
 # You MUST call iplug_configure_target(<target_name> <app|vst2|vst3|...>) for things to build correctly.
@@ -52,7 +52,7 @@ iplug_configure_target(${TARGET} app)
 # iplug_target_add(${TARGET} PUBLIC LINK iPlug2_VST2 _base RESOURCE ${RESOURCES})
 # iplug_configure_target(${TARGET} vst2)
 
-set(TARGET vst3)
+set(TARGET ${PROJECT_NAME}-vst3)
 add_library(${TARGET} MODULE ${SRC_FILES})
 iplug_target_add(${TARGET} PUBLIC LINK iPlug2_VST3 _base RESOURCE ${RESOURCES})
 iplug_configure_target(${TARGET} vst3)

--- a/TemplateProject/scripts/makedist-mac.sh
+++ b/TemplateProject/scripts/makedist-mac.sh
@@ -6,9 +6,9 @@ BASEDIR=$(dirname $0)
 
 cd $BASEDIR/..
 
-if [ -d build-mac ]; then
-  sudo rm -f -R build-mac
-fi
+# if [ -d build-mac ]; then
+#   sudo rm -f -R build-mac
+# fi
 
 #---------------------------------------------------------------------------------------------------------
 #variables
@@ -117,37 +117,37 @@ touch *.cpp
 #---------------------------------------------------------------------------------------------------------
 #remove existing binaries
 
-echo "remove existing binaries"
-echo ""
+# echo "remove existing binaries"
+# echo ""
 
-if [ -d $APP ]; then
-  sudo rm -f -R -f $APP
-fi
+# if [ -d $APP ]; then
+#   sudo rm -f -R -f $APP
+# fi
 
-if [ -d $AU ]; then
- sudo rm -f -R $AU
-fi
+# if [ -d $AU ]; then
+#  sudo rm -f -R $AU
+# fi
 
-if [ -d $VST2 ]; then
-  sudo rm -f -R $VST2
-fi
+# if [ -d $VST2 ]; then
+#   sudo rm -f -R $VST2
+# fi
 
-if [ -d $VST3 ]; then
-  sudo rm -f -R $VST3
-fi
+# if [ -d $VST3 ]; then
+#   sudo rm -f -R $VST3
+# fi
 
-if [ -d "${AAX}" ]; then
-  sudo rm -f -R "${AAX}"
-fi
+# if [ -d "${AAX}" ]; then
+#   sudo rm -f -R "${AAX}"
+# fi
 
-if [ -d "${AAX_FINAL}" ]; then
-  sudo rm -f -R "${AAX_FINAL}"
-fi
+# if [ -d "${AAX_FINAL}" ]; then
+#   sudo rm -f -R "${AAX_FINAL}"
+# fi
 
 #---------------------------------------------------------------------------------------------------------
 # build xcode project. Change target to build individual formats, or add to All target in the xcode project
 
-xcodebuild -project ./projects/$PLUGIN_NAME-macOS.xcodeproj -xcconfig ./config/$PLUGIN_NAME-mac.xcconfig DEMO_VERSION=$DEMO -target "All" -UseModernBuildSystem=NO -configuration Release | tee build-mac.log | xcpretty #&& exit ${PIPESTATUS[0]}
+xcodebuild -project ./build-mac/$PLUGIN_NAME-macOS.xcodeproj -xcconfig ./config/$PLUGIN_NAME-mac.xcconfig DEMO_VERSION=$DEMO -alltargets -UseModernBuildSystem=NO -configuration RelWithDebInfo | tee build-mac.log | xcpretty #&& exit ${PIPESTATUS[0]}
 
 if [ "${PIPESTATUS[0]}" -ne "0" ]; then
   echo "ERROR: build failed, aborting"
@@ -337,7 +337,7 @@ sudo rm -R -f build-mac/*-dSYMs.zip
 
 echo "packaging dSYMs"
 echo ""
-zip -r ./build-mac/$ARCHIVE_NAME-dSYMs.zip ./build-mac/*.dSYM
+zip -r ./build-mac/$ARCHIVE_NAME-dSYMs.zip ./build-mac/**/*.dSYM
 
 #---------------------------------------------------------------------------------------------------------
 

--- a/TemplateProject/scripts/makedist-win.bat
+++ b/TemplateProject/scripts/makedist-win.bat
@@ -81,7 +81,7 @@ REM msbuild TemplateProject.sln /p:configuration=release /p:platform=win32 /nolo
 
 REM echo Building 64 bit binaries...
 REM add projects with /t to build VST2 and AAX
-msbuild TemplateProject.sln /t:TemplateProject-app;TemplateProject-vst3 /p:configuration=release /p:platform=x64 /nologo /verbosity:minimal /fileLogger /m /flp:logfile=build-win.log;errorsonly;append
+msbuild build-win/TemplateProject.sln /t:TemplateProject-app;TemplateProject-vst3 /p:configuration=release /p:platform=x64 /nologo /verbosity:minimal /fileLogger /m /flp:logfile=build-win.log;errorsonly;append
 
 REM --echo Copying AAX Presets
 


### PR DESCRIPTION
cmake generated files for the workflows in iPlugOOS template to run.
Small changes needed to be done in the iPlug2 repo.

Now entire projects can be configured with only the CMakeLists.txt for every project without needing projects specific solutions files.

Some formatting of the code was also made, that's why the diff looks bigger than it is.