### PR TITLE
Fix win ci-build

### DIFF
--- a/common-win.props
+++ b/common-win.props
@@ -66,7 +66,7 @@
     <COPY_VST2>1</COPY_VST2>
     <REAPER_INC_PATHS>$(IPLUG_DEPS_PATH)/Reaper;$(IPLUG_PATH)\ReaperExt;</REAPER_INC_PATHS>
     <AAX_ICON>$(AAX_SDK)\Utilities\PlugIn.ico</AAX_ICON>
-    <VST_ICON>$(VST3_SDK)\doc\artwork\VST_Logo_Steinberg.ico</VST_ICON>
+    <VST_ICON>$(IPLUG2_ROOT)\Scripts\icons\VST_Logo_Steinberg.ico</VST_ICON>
     <FAUST_LIB_PATH>$(DEPS_PATH)\Build\win\Faust\lib</FAUST_LIB_PATH>
   </PropertyGroup>
   <PropertyGroup>


### PR DESCRIPTION
This PR should fix the release-native ci script, which was failing on windows due to missing VST ico 