### PR TITLE
Update makezip-win.py to resolve Syntax Warnings

### DIFF
--- a/TemplateProject/scripts/makezip-win.py
+++ b/TemplateProject/scripts/makezip-win.py
@@ -3,9 +3,9 @@ import zipfile, os, fileinput, string, sys, shutil
 scriptpath = os.path.dirname(os.path.realpath(__file__))
 projectpath = os.path.abspath(os.path.join(scriptpath, os.pardir))
 
-IPLUG2_ROOT = "..\..\iPlug2"
+IPLUG2_ROOT = "..\\..\\iPlug2"
 
-sys.path.insert(0, os.path.join(scriptpath, IPLUG2_ROOT + '\Scripts'))
+sys.path.insert(0, os.path.join(scriptpath, IPLUG2_ROOT + '\\Scripts'))
 
 from get_archive_name import get_archive_name
 


### PR DESCRIPTION
Resolve issues with error messages:

- \makezip-win.py:6: SyntaxWarning: invalid escape sequence '\.'
- makezip-win.py:8: SyntaxWarning: invalid escape sequence '\S'